### PR TITLE
Don't show spectators in results screen

### DIFF
--- a/src/net/fe/Session.java
+++ b/src/net/fe/Session.java
@@ -1,6 +1,7 @@
 package net.fe;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -125,6 +126,17 @@ public class Session implements Serializable {
 	 */
 	public Player[] getPlayers() {
 		return players.values().toArray(new Player[players.size()]);
+	}
+	
+	/**
+	 * Returns a list of players, filtered to not include players that are spectators
+	 */
+	public Player[] getNonSpectators() {
+		ArrayList<Player> ans = new ArrayList<Player>();
+		for(Player p : this.getPlayers()) {
+			if(!p.isSpectator()) ans.add(p);
+		}
+		return ans.toArray(new Player[ans.size()]);
 	}
 	
 	/**

--- a/src/net/fe/builderStage/DraftViewStage.java
+++ b/src/net/fe/builderStage/DraftViewStage.java
@@ -208,8 +208,7 @@ public class DraftViewStage extends Stage {
 		
 		// Timers
 		timers = new ArrayList<DraftTimer>();
-		for(Player p : session.getPlayers()) {
-			if(p.isSpectator()) continue;
+		for(Player p : session.getNonSpectators()) {
 			int x = p.getParty().getColor().equals(Party.TEAM_BLUE) ? 5 : 410;
 			float totalTime = Math.round(TIME_PER_TURN * draftOrder.length / 5.0f) * 5 + BASE_TIME;
 			DraftTimer dt = new DraftTimer(x, 277, totalTime, Math.round(totalTime/12), p);
@@ -471,8 +470,7 @@ public class DraftViewStage extends Stage {
 		Renderer.drawTriangle(cX-4, 8, cX, 12, cX+4, 8, 0.0f, round.charAt(0) == 'B' ? BLUE_TURN : RED_TURN);
 		
 		// Player lists
-		for(Player p : session.getPlayers()) {
-			if(p.isSpectator()) continue;
+		for(Player p : session.getNonSpectators()) {
 			int y = 30;
 			for(Unit u : p.getParty()) {
 				int nameWidth = FEResources.getBitmapFont("default_med").getStringWidth(u.name);

--- a/src/net/fe/builderStage/TeamDraftStage.java
+++ b/src/net/fe/builderStage/TeamDraftStage.java
@@ -222,8 +222,7 @@ public class TeamDraftStage extends Stage {
 		
 		// Timers
 		timers = new ArrayList<DraftTimer>();
-		for(Player p : session.getPlayers()) {
-			if(p.isSpectator()) continue;
+		for(Player p : session.getNonSpectators()) {
 			int x = p.getParty().getColor().equals(Party.TEAM_BLUE) ? 5 : 410;
 			float totalTime = Math.round(TIME_PER_TURN * draftOrder.length / 5.0f) * 5 + BASE_TIME;
 			DraftTimer dt = new DraftTimer(x, 277, totalTime, Math.round(totalTime/12), p);
@@ -636,8 +635,7 @@ public class TeamDraftStage extends Stage {
 		Renderer.drawTriangle(cX-4, 8, cX, 12, cX+4, 8, 0.0f, round.charAt(0) == 'B' ? BLUE_TURN : RED_TURN);
 		
 		// Player lists
-		for(Player p : session.getPlayers()) {
-			if(p.isSpectator()) continue;
+		for(Player p : session.getNonSpectators()) {
 			int y = 30;
 			for(Unit u : p.getParty()) {
 				int nameWidth = FEResources.getBitmapFont("default_med").getStringWidth(u.name);

--- a/src/net/fe/builderStage/WaitStage.java
+++ b/src/net/fe/builderStage/WaitStage.java
@@ -53,8 +53,8 @@ public class WaitStage extends Stage {
 	protected void init() {
 		readyStatus = new HashMap<Byte, Boolean>();
 		sentStartMessage = false;
-		for(Player p : session.getPlayers()) {
-			if(!p.isSpectator()) readyStatus.put(p.getID(), false);
+		for(Player p : session.getNonSpectators()) {
+			readyStatus.put(p.getID(), false);
 		}
 		messages = new ArrayList<PartyMessage>();
 	}

--- a/src/net/fe/overworldStage/EndGameStage.java
+++ b/src/net/fe/overworldStage/EndGameStage.java
@@ -49,10 +49,14 @@ public class EndGameStage extends Stage {
 		super("end");
 		this.session = session;
 		addEntity(new RunesBg(new Color(0xd2b48c)));
+		int renderedPlayers = -1;
 		for(int x=0; x<session.numPlayers(); x++) {
 			Player p = session.getPlayers()[x];
-			for(int i=0; i<p.getParty().size(); i++) {
-				addEntity(new UnitIcon(p.getParty().getUnit(i), X0+x*X_SPACING, Y0+i*Y_SPACING, 0.5f));
+			if (p.getTeam() != Player.TEAM_SPECTATOR) {
+				renderedPlayers++;
+				for(int i=0; i<p.getParty().size(); i++) {
+					addEntity(new UnitIcon(p.getParty().getUnit(i), X0+renderedPlayers*X_SPACING, Y0+i*Y_SPACING, 0.5f));
+				}
 			}
 		}
 		processAddStack();
@@ -104,23 +108,27 @@ public class EndGameStage extends Stage {
 		super.render();
 		Renderer.drawString("default_med", "Press Enter to return to lobby...", 200, 5, 0.5f);
 		String[] stats = {"Kills", "Assists", "Damage", "Healing"};
+		int renderedPlayers = -1;
 		for(int i=0; i<session.numPlayers(); i++) {
 			Player p = session.getPlayers()[i];
-			Renderer.drawBorderedRectangle(X0+X_SPACING*i, Y0-3, X0+X_SPACING*(i+1), Y0+Y_SPACING*p.getParty().size(), 0.9f, 
-					 FightStage.NEUTRAL, FightStage.BORDER_LIGHT, FightStage.BORDER_DARK);
-			Renderer.drawBorderedRectangle(X0+X_SPACING*i, Y0-28, X0+X_SPACING*(i+1), Y0-8, 0.9f, 
-					 FightStage.NEUTRAL, FightStage.BORDER_LIGHT, FightStage.BORDER_DARK);
-			for(int k=0; k<stats.length; k++) {
-				Renderer.drawString("default_med", stats[k], X0+70+40*k+X_SPACING*i, Y0-25, 0.5f);
-			}
-			Renderer.drawString("default_med", "Name", X0+20+X_SPACING*i, Y0-25, 0.5f);
-			for(int j=0; j<p.getParty().size(); j++) {
-				Unit u = p.getParty().getUnit(j);
-				Renderer.drawString("default_med", u.name, X0+20+X_SPACING*i, Y0+j*Y_SPACING, 0.5f);
+			if (p.getTeam() != Player.TEAM_SPECTATOR) {
+				renderedPlayers++;
+				Renderer.drawBorderedRectangle(X0+X_SPACING*renderedPlayers, Y0-3, X0+X_SPACING*(renderedPlayers+1), Y0+Y_SPACING*p.getParty().size(), 0.9f, 
+						FightStage.NEUTRAL, FightStage.BORDER_LIGHT, FightStage.BORDER_DARK);
+				Renderer.drawBorderedRectangle(X0+X_SPACING*renderedPlayers, Y0-28, X0+X_SPACING*(renderedPlayers+1), Y0-8, 0.9f, 
+						FightStage.NEUTRAL, FightStage.BORDER_LIGHT, FightStage.BORDER_DARK);
 				for(int k=0; k<stats.length; k++) {
-					Renderer.drawString("default_med", u.getBattleStat(stats[k]), X0+75+40*k+X_SPACING*i, Y0+j*Y_SPACING, 0.5f);
+					Renderer.drawString("default_med", stats[k], X0+70+40*k+X_SPACING*renderedPlayers, Y0-25, 0.5f);
 				}
-			}	
+				Renderer.drawString("default_med", "Name", X0+20+X_SPACING*renderedPlayers, Y0-25, 0.5f);
+				for(int j=0; j<p.getParty().size(); j++) {
+					Unit u = p.getParty().getUnit(j);
+					Renderer.drawString("default_med", u.name, X0+20+X_SPACING*renderedPlayers, Y0+j*Y_SPACING, 0.5f);
+					for(int k=0; k<stats.length; k++) {
+						Renderer.drawString("default_med", u.getBattleStat(stats[k]), X0+75+40*k+X_SPACING*renderedPlayers, Y0+j*Y_SPACING, 0.5f);
+					}
+				}
+			}
 		}
 	}
 

--- a/src/net/fe/overworldStage/EndGameStage.java
+++ b/src/net/fe/overworldStage/EndGameStage.java
@@ -49,14 +49,11 @@ public class EndGameStage extends Stage {
 		super("end");
 		this.session = session;
 		addEntity(new RunesBg(new Color(0xd2b48c)));
-		int renderedPlayers = -1;
-		for(int x=0; x<session.numPlayers(); x++) {
-			Player p = session.getPlayers()[x];
-			if (p.getTeam() != Player.TEAM_SPECTATOR) {
-				renderedPlayers++;
-				for(int i=0; i<p.getParty().size(); i++) {
-					addEntity(new UnitIcon(p.getParty().getUnit(i), X0+renderedPlayers*X_SPACING, Y0+i*Y_SPACING, 0.5f));
-				}
+		Player[] toRender = session.getNonSpectators();
+		for(int x=0; x< toRender.length; x++) {
+			Player p = toRender[x];
+			for(int i=0; i<p.getParty().size(); i++) {
+				addEntity(new UnitIcon(p.getParty().getUnit(i), X0+x*X_SPACING, Y0+i*Y_SPACING, 0.5f));
 			}
 		}
 		processAddStack();
@@ -108,25 +105,22 @@ public class EndGameStage extends Stage {
 		super.render();
 		Renderer.drawString("default_med", "Press Enter to return to lobby...", 200, 5, 0.5f);
 		String[] stats = {"Kills", "Assists", "Damage", "Healing"};
-		int renderedPlayers = -1;
-		for(int i=0; i<session.numPlayers(); i++) {
-			Player p = session.getPlayers()[i];
-			if (p.getTeam() != Player.TEAM_SPECTATOR) {
-				renderedPlayers++;
-				Renderer.drawBorderedRectangle(X0+X_SPACING*renderedPlayers, Y0-3, X0+X_SPACING*(renderedPlayers+1), Y0+Y_SPACING*p.getParty().size(), 0.9f, 
-						FightStage.NEUTRAL, FightStage.BORDER_LIGHT, FightStage.BORDER_DARK);
-				Renderer.drawBorderedRectangle(X0+X_SPACING*renderedPlayers, Y0-28, X0+X_SPACING*(renderedPlayers+1), Y0-8, 0.9f, 
-						FightStage.NEUTRAL, FightStage.BORDER_LIGHT, FightStage.BORDER_DARK);
+		Player[] toRender = session.getNonSpectators();
+		for(int i=0; i < toRender.length; i++) {
+			Player p = toRender[i];
+			Renderer.drawBorderedRectangle(X0+X_SPACING*i, Y0-3, X0+X_SPACING*(i+1), Y0+Y_SPACING*p.getParty().size(), 0.9f, 
+					FightStage.NEUTRAL, FightStage.BORDER_LIGHT, FightStage.BORDER_DARK);
+			Renderer.drawBorderedRectangle(X0+X_SPACING*i, Y0-28, X0+X_SPACING*(i+1), Y0-8, 0.9f, 
+					FightStage.NEUTRAL, FightStage.BORDER_LIGHT, FightStage.BORDER_DARK);
+			for(int k=0; k<stats.length; k++) {
+				Renderer.drawString("default_med", stats[k], X0+70+40*k+X_SPACING*i, Y0-25, 0.5f);
+			}
+			Renderer.drawString("default_med", "Name", X0+20+X_SPACING*i, Y0-25, 0.5f);
+			for(int j=0; j<p.getParty().size(); j++) {
+				Unit u = p.getParty().getUnit(j);
+				Renderer.drawString("default_med", u.name, X0+20+X_SPACING*i, Y0+j*Y_SPACING, 0.5f);
 				for(int k=0; k<stats.length; k++) {
-					Renderer.drawString("default_med", stats[k], X0+70+40*k+X_SPACING*renderedPlayers, Y0-25, 0.5f);
-				}
-				Renderer.drawString("default_med", "Name", X0+20+X_SPACING*renderedPlayers, Y0-25, 0.5f);
-				for(int j=0; j<p.getParty().size(); j++) {
-					Unit u = p.getParty().getUnit(j);
-					Renderer.drawString("default_med", u.name, X0+20+X_SPACING*renderedPlayers, Y0+j*Y_SPACING, 0.5f);
-					for(int k=0; k<stats.length; k++) {
-						Renderer.drawString("default_med", u.getBattleStat(stats[k]), X0+75+40*k+X_SPACING*renderedPlayers, Y0+j*Y_SPACING, 0.5f);
-					}
+					Renderer.drawString("default_med", u.getBattleStat(stats[k]), X0+75+40*k+X_SPACING*i, Y0+j*Y_SPACING, 0.5f);
 				}
 			}
 		}

--- a/src/net/fe/overworldStage/OverworldStage.java
+++ b/src/net/fe/overworldStage/OverworldStage.java
@@ -75,8 +75,8 @@ public class OverworldStage extends Stage {
 		System.out.println(session.getObjective().getDescription());
 		chat = new Chat();
 		turnOrder = new ArrayList<Player>();
-		for(Player p : session.getPlayers()) {
-			if(!p.isSpectator()) turnOrder.add(p);
+		for(Player p : session.getNonSpectators()) {
+			turnOrder.add(p);
 		}
 		Collections.sort(turnOrder, new Comparator<Player>() {
 			@Override
@@ -493,16 +493,10 @@ public class OverworldStage extends Stage {
 	}
 	
 	/**
-	 * Gets the non spectators.
-	 *
-	 * @return the non spectators
+	 * Returns a list of players, filtered to not include players that are spectators
 	 */
-	public ArrayList<Player> getNonSpectators() {
-		ArrayList<Player> ans = new ArrayList<Player>();
-		for(Player p : session.getPlayers()) {
-			if(!p.isSpectator()) ans.add(p);
-		}
-		return ans;
+	public Player[] getNonSpectators() {
+		return session.getNonSpectators();
 	}
 	
 	/**


### PR DESCRIPTION
Basically, spectators don't have any useful information to display in the EndGameStage, but can still force nonspectator information out-of-bounds. So, this modifies EndGameStage to not show spectator information.