### PR TITLE
Move fast when pressing 'X'

### DIFF
--- a/src/net/fe/overworldStage/ClientOverworldStage.java
+++ b/src/net/fe/overworldStage/ClientOverworldStage.java
@@ -253,21 +253,23 @@ public class ClientOverworldStage extends OverworldStage {
 		MapAnimation.updateAll();
 		if (onControl) {
 			List<KeyboardEvent> keys = Game.getKeys();
+			boolean moveFast = Keyboard.isKeyDown(FEResources.getKeyMapped(Keyboard.KEY_X));
+			float timer = context.getCursorSpeed(moveFast);
 			if (Keyboard.isKeyDown(FEResources.getKeyMapped(Keyboard.KEY_UP)) && repeatTimers[0] == 0) {
 				context.onUp();
-				repeatTimers[0] = 0.12f;
+				repeatTimers[0] = timer;
 			}
 			if (Keyboard.isKeyDown(FEResources.getKeyMapped(Keyboard.KEY_DOWN)) && repeatTimers[1] == 0) {
 				context.onDown();
-				repeatTimers[1] = 0.12f;
+				repeatTimers[1] = timer;
 			}
 			if (Keyboard.isKeyDown(FEResources.getKeyMapped(Keyboard.KEY_LEFT)) && repeatTimers[2] == 0) {
 				context.onLeft();
-				repeatTimers[2] = 0.12f;
+				repeatTimers[2] = timer;
 			}
 			if (Keyboard.isKeyDown(FEResources.getKeyMapped(Keyboard.KEY_RIGHT)) && repeatTimers[3] == 0) {
 				context.onRight();
-				repeatTimers[3] = 0.12f;
+				repeatTimers[3] = timer;
 			}
 			for(KeyboardEvent ke : keys) {
 				if(ke.state) {

--- a/src/net/fe/overworldStage/OverworldContext.java
+++ b/src/net/fe/overworldStage/OverworldContext.java
@@ -33,6 +33,13 @@ public abstract class OverworldContext {
 		cursor = stage.cursor;
 		grid = stage.grid;
 	}
+	
+	/**
+	 * Cursor speed
+	 */
+	public float getCursorSpeed(boolean fast) {
+		return 0.12f;
+	}
 
 	/**
 	 * On select.

--- a/src/net/fe/overworldStage/context/Idle.java
+++ b/src/net/fe/overworldStage/context/Idle.java
@@ -57,6 +57,13 @@ public class Idle extends CursorContext {
 	public void cleanUp(){
 		removeZones();
 	}
+	
+	@Override
+	public float getCursorSpeed(boolean fast) {
+		if (fast)
+			return 0.03f;
+		return super.getCursorSpeed(fast);
+	}
 
 	/* (non-Javadoc)
 	 * @see net.fe.overworldStage.OverworldContext#onSelect()


### PR DESCRIPTION
Inspired by /u/Cardalilyn on reddit.

Currently, the cursor speed on the map is fixed to a relatively slow
speed suitable for selecting a unit and giving it orders. However, the
current speed is ill suited for quickly moving across the map to access
a unit there. This patch makes it so that when the 'X' button is
pressed, the cursor moves faster, emulating the behavior of the GBA
games.