### PR TITLE
Hide the path and indicators while moving

### DIFF
--- a/src/net/fe/overworldStage/context/UnitSelected.java
+++ b/src/net/fe/overworldStage/context/UnitSelected.java
@@ -81,6 +81,8 @@ public class UnitSelected extends CursorContext {
 							selected, false, false).startContext();
 				}
 			});
+			// We don't want to display the path/range while moving.
+			cleanUp();
 		}
 	}
 


### PR DESCRIPTION
Inspired by /u/Cardalilyn on reddit.

Currently when a character moves the path arrow as well as the tile
indicators are still displayed, while on the GBA games it disappears as
soon as the destination is selected.  This patch makes it so that FEMP
behaves like the GBA games in that regard.