### PR TITLE
Allow to end turn when selecting an invalid unit

### DIFF
--- a/src/net/fe/overworldStage/context/Idle.java
+++ b/src/net/fe/overworldStage/context/Idle.java
@@ -67,8 +67,7 @@ public class Idle extends CursorContext {
 		AudioPlayer.playAudio("select");
 		if(u!=null && u.getParty() == player.getParty() && !u.hasMoved()){
 			new UnitSelected(stage, this, u).startContext();
-		}
-		if(u == null){
+		} else {
 			new EndMenu(stage, this).startContext();
 		}
 


### PR DESCRIPTION
Currently, selecting (pressing 'Z') on a tile with either a friendly
unit that already moved (greyed out) or an enemy unit has no action.

This patch makes it so that instead, it will bring out the "End turn"
menu, which is the same behavior as when selecting an empty tile. This
is coherent with the behavior of the GBA games (on the GBA games,
selecting an enemy unit would display their movement and attack ranges,
but FEMP already does this when simply hovering over the unit).