### PR TITLE
Remember (locally) the path

### DIFF
--- a/src/net/fe/overworldStage/Grid.java
+++ b/src/net/fe/overworldStage/Grid.java
@@ -198,6 +198,41 @@ public class Grid{
 		}
 		return false;
 	}
+	
+	public Path improvePath(Unit unit, int x, int y, Path p) {
+		if (grid[y][x] != null && grid[y][x] != unit)
+			return null;
+		
+		if (p == null)
+			return getShortestPath(unit, x, y);
+
+		Path improved = new Path();
+		
+		int move = unit.get("Mov");
+		Node last = null;
+		// Rebuild the current path, counting the movement used
+		for (Node node : p.getAllNodes()) {
+			improved.add(node);
+			if (last != null) // The first node is the unit's current position
+				move -= terrain[node.y][node.x].getMoveCost(unit.getTheClass());
+			last = node;
+			
+			// If we go somewhere that is already on the path, just cut the path.
+			if (node.x == x && node.y == y)
+				return improved;
+		}
+		
+		// Sanity check: we should be moving exactly one additional tile.
+		if (last.distance(new Node(x, y)) != 1)
+			return getShortestPath(unit, x, y);
+
+		// Check that we can actually extend the path
+		if (move < terrain[y][x].getMoveCost(unit.getTheClass()))
+			return getShortestPath(unit, x, y);
+		
+		improved.add(new Node(x, y));
+		return improved;
+	}
 
 	/**
 	 * Gets the shortest path.
@@ -208,8 +243,8 @@ public class Grid{
 	 * @return the shortest path
 	 */
 	public Path getShortestPath(Unit unit, int x, int y) {
-		int move = unit.get("Mov");
 		if(grid[y][x] != null && grid[y][x] != unit) return null;
+		int move = unit.get("Mov");
 		Set<Node> closed = new HashSet<Node>();
 		Set<Node> open = new HashSet<Node>();
 

--- a/src/net/fe/overworldStage/context/UnitSelected.java
+++ b/src/net/fe/overworldStage/context/UnitSelected.java
@@ -114,8 +114,7 @@ public class UnitSelected extends CursorContext {
 	 */
 	private void updatePath() {
 		stage.removeEntity(path);
-		path = stage.grid.getShortestPath(selected, cursor.getXCoord(),
-				cursor.getYCoord());
+		path = stage.grid.improvePath(selected, cursor.getXCoord(), cursor.getYCoord(), path);
 		if (path != null) {
 			stage.addEntity(path);
 		}


### PR DESCRIPTION
Currently, the displayed path for a unit is always a computed shortest
path. This sometimes causes unnecessary "path jumps" (for instance, if
you go one down then one left, the path may immediately change to one
left then one down).

This patch makes it so that FEMP emulates the behavior of the GBA games:
if the unit still has enough movement remaining, the existing path is
extended (and if the new tile was already on the path, it is simply
truncated). In case there is not enough movement left, the old behavior
is kept.

This is a purely local change: even though the current player will see
the unit follow the selected path, a networked opponent or spectator
will possibly see a different path that corresponds to the shortest
path. This is a compromise that allows to keep the current efficiency of
FEMP sending only the new end position (not the complete path) over the
network while providing a more user-friendly behavior inspired from the
GBA games.