### PR TITLE
Add an additional "special" key

### DIFF
--- a/src/net/fe/overworldStage/ClientOverworldStage.java
+++ b/src/net/fe/overworldStage/ClientOverworldStage.java
@@ -274,7 +274,9 @@ public class ClientOverworldStage extends OverworldStage {
 					if(ke.key == FEResources.getKeyMapped(Keyboard.KEY_Z)) 
 						context.onSelect();
 					else if (ke.key == FEResources.getKeyMapped(Keyboard.KEY_X))
-						context.onCancel(); 
+						context.onCancel();
+					else if (ke.key == FEResources.getKeyMapped(Keyboard.KEY_C))
+						context.onNextUnit();
 				}
 			}
 		}

--- a/src/net/fe/overworldStage/OverworldContext.java
+++ b/src/net/fe/overworldStage/OverworldContext.java
@@ -46,6 +46,9 @@ public abstract class OverworldContext {
 		AudioPlayer.playAudio("cancel");
 		prev.startContext();
 	}
+	
+	public void onNextUnit() {
+	}
 
 	/**
 	 * On up.

--- a/src/net/fe/overworldStage/context/Idle.java
+++ b/src/net/fe/overworldStage/context/Idle.java
@@ -73,6 +73,41 @@ public class Idle extends CursorContext {
 		}
 
 	}
+	
+	@Override
+	public void onNextUnit() {
+		Unit hovered = getHoveredUnit();
+		Unit target = null;
+		boolean found = false;
+		for (Unit unit : player.getParty()) {
+			if (unit.hasMoved())
+				continue;
+			
+			// If the current unit was found, the target is the next one.
+			if (found) {
+				target = unit;
+				break;
+			}
+			
+			// By default, the target is the first valid unit...
+			if (target == null)
+				target = unit;
+			
+			// ... which is the one we use if there is no hovered target (but also if the hovered unit is the last valid unit).
+			if (hovered == null)
+				break;
+			
+			if (unit == hovered)
+				found = true;
+		}
+		
+		if (target != null) {
+			cursorWillChange();
+			cursor.setXCoord(target.getXCoord());
+			cursor.setYCoord(target.getYCoord());
+			cursorChanged();
+		}
+	}
 
 
 	/* (non-Javadoc)

--- a/src/net/fe/overworldStage/context/UnitSelected.java
+++ b/src/net/fe/overworldStage/context/UnitSelected.java
@@ -83,6 +83,14 @@ public class UnitSelected extends CursorContext {
 			});
 		}
 	}
+	
+	@Override
+	public void onNextUnit() {
+		cursor.setXCoord(selected.getXCoord());
+		cursor.setYCoord(selected.getYCoord());
+		updatePath();
+		AudioPlayer.playAudio("cancel");
+	}
 
 	/* (non-Javadoc)
 	 * @see net.fe.overworldStage.OverworldContext#onCancel()


### PR DESCRIPTION
Inspired by /u/Cardalilyn on reddit.

Currently, there are two mains keys in FEMP, 'Z' and 'X'. They
correspond to the "OK" and "Cancel" behavior of the 'A' and 'B' buttons
on the GBA games. This patch adds a third key, 'C', for implementing
"next unit" behavior. It currently does two things, taken from the
behavior of the 'L' button in the GBA games:

 - When a unit is selected, pressing 'C' will place the cursor on the
   selected unit immediately.

 - When no unit is selected, pressing 'C' will rotate the cursor through
   the player-controlled units that have not moved yet.