### PR TITLE
Fix candidate for "Skip your opponent's turn" bug

### DIFF
--- a/src/net/fe/overworldStage/ClientOverworldStage.java
+++ b/src/net/fe/overworldStage/ClientOverworldStage.java
@@ -350,7 +350,6 @@ public class ClientOverworldStage extends OverworldStage {
 	public void end(){
 		FEMultiplayer.getClient().sendMessage(new EndTurn());
 		selectedUnit = null;
-		removeExtraneousEntities();
 	}
 	
 	/* (non-Javadoc)
@@ -358,6 +357,7 @@ public class ClientOverworldStage extends OverworldStage {
 	 */
 	@Override
 	protected void doEndTurn(int playerID) {
+		removeExtraneousEntities();
 		super.doEndTurn(playerID);
 		context.cleanUp();
 		// reset assists

--- a/src/net/fe/overworldStage/OverworldStage.java
+++ b/src/net/fe/overworldStage/OverworldStage.java
@@ -269,17 +269,23 @@ public class OverworldStage extends Stage {
 						chat.add(p, chatMsg.text);
 			}
 			else if(message instanceof EndTurn) {
-				if(this instanceof ClientOverworldStage){
-					((EndTurn) message).checkHp(false);
-				} else {
-					((EndTurn) message).checkHp(true);
+				//Only end the turn if it is this player's turn to end. (Or, if for some reason we want to let
+				//the server end turns in the future.
+				System.out.println("" + message.origin + " " + currentPlayer);
+				if(message.origin == getCurrentPlayer().getID() || message.origin == 0){
+
+					if(this instanceof ClientOverworldStage){
+						((EndTurn) message).checkHp(false);
+					} else {
+						((EndTurn) message).checkHp(true);
+					}
+					doEndTurn(message.origin);
+					currentPlayer++;
+					if(currentPlayer >= turnOrder.size()) {
+						currentPlayer = 0;
+					}
+					doStartTurn(message.origin);
 				}
-				doEndTurn(message.origin);
-				currentPlayer++;
-				if(currentPlayer >= turnOrder.size()) {
-					currentPlayer = 0;
-				}
-				doStartTurn(message.origin);
 			}
 			else if(message instanceof QuitMessage) {
 				Player leaver = null;


### PR DESCRIPTION
NOTE: I say fix candidate because I was never able to get the bug to happen on my machine, so it will need to be checked by someone who can get it to happen.  On the other hand, I have checked to make sure that it is at minimum no worse than it was before, from a general use perspective.

Note also that, while the same thing could be done to prevent command messages on your opponent's turns, I didn't do that yet because I want to ensure that there are no cases in which it is intended to allow command messages on your opponent's turns.

Also of note, this bug and a similar bug that allow for illegal extra actions on your own turn are actually fairly different fixes.  The other bug will require either substantial fiddling with the client, or rewriting a good chunk of the way the netcode works (if I understand what I'm seeing correctly).  So don't just deny this one because you think there is one blanket fix - in this case, there isn't one, at least so far as 3 hours of fiddling tells me.