### PR TITLE
Conditionally add "Next Unit" command to non-unit command menu

### DIFF
--- a/src/net/fe/overworldStage/context/EndMenu.java
+++ b/src/net/fe/overworldStage/context/EndMenu.java
@@ -1,6 +1,8 @@
 package net.fe.overworldStage.context;
 
 import chu.engine.anim.AudioPlayer;
+import net.fe.Player;
+import net.fe.unit.Unit;
 import net.fe.overworldStage.Menu;
 import net.fe.overworldStage.MenuContext;
 import net.fe.overworldStage.OverworldContext;
@@ -8,19 +10,26 @@ import net.fe.overworldStage.ClientOverworldStage;
 
 // TODO: Auto-generated Javadoc
 /**
- * The Class EndMenu.
+ * The menu that is used when there is no refreshed unit on the currently selected space
  */
-public class EndMenu extends MenuContext<String> {
-
+public final class EndMenu extends MenuContext<String> {
+	
+	private final static String next = "Next Unit";
+	private final static String end = "End Turn";
+	
 	/**
 	 * Instantiates a new end menu.
 	 *
 	 * @param stage the stage
-	 * @param prev the prev
+	 * @param prev the previous context. This expects the previous
+	 *      stage to be an Idle for the "Next Unit" button to work.
 	 */
 	public EndMenu(ClientOverworldStage stage, OverworldContext prev) {
 		super(stage, prev, new Menu<String>());
-		menu.addItem("End");
+		if (hasActionableUnits(stage.getCurrentPlayer())) {
+			menu.addItem(next);
+		}
+		menu.addItem(end);
 	}
 
 	/* (non-Javadoc)
@@ -29,8 +38,16 @@ public class EndMenu extends MenuContext<String> {
 	@Override
 	public void onSelect(String selectedItem) {
 		AudioPlayer.playAudio("select");
-		if(menu.getSelection().equals("End")){
-			stage.end();
+		switch (selectedItem) {
+			case next: {
+				prev.startContext();
+				prev.onNextUnit();
+				break;
+			}
+			case end: {
+				stage.end();
+				break;
+			}
 		}
 	}
 
@@ -48,6 +65,17 @@ public class EndMenu extends MenuContext<String> {
 	@Override
 	public void onRight() {
 		
+	}
+
+	/**
+	 * Returns true if the player has any units that may perform actions
+	 */
+	private static boolean hasActionableUnits(Player p) {
+		boolean retVal = false;
+		for (Unit u : p.getParty()) {
+			retVal = retVal || (!u.hasMoved() && u.getHp() > 0);
+		}
+		return retVal;
 	}
 
 }

--- a/src/net/fe/overworldStage/context/EndMenu.java
+++ b/src/net/fe/overworldStage/context/EndMenu.java
@@ -15,7 +15,7 @@ import net.fe.overworldStage.ClientOverworldStage;
 public final class EndMenu extends MenuContext<String> {
 	
 	private final static String next = "Next Unit";
-	private final static String end = "End Turn";
+	private final static String end = "End";
 	
 	/**
 	 * Instantiates a new end menu.

--- a/src/net/fe/overworldStage/context/Idle.java
+++ b/src/net/fe/overworldStage/context/Idle.java
@@ -34,18 +34,6 @@ public class Idle extends CursorContext {
 	 * @see net.fe.overworldStage.OverworldContext#startContext()
 	 */
 	public void startContext(){
-//		boolean movable = false;
-//		for(Unit u: stage.getCurrentPlayer().getParty()){
-//			if(!u.hasMoved()){
-//				movable = true;
-//			}
-//		}
-//		if(movable){
-//			super.startContext();
-//			cursorChanged();
-//		} else {
-//			stage.end();
-//		}
 		super.startContext();
 		cursorChanged();
 	}
@@ -86,7 +74,7 @@ public class Idle extends CursorContext {
 		Unit target = null;
 		boolean found = false;
 		for (Unit unit : player.getParty()) {
-			if (unit.hasMoved())
+			if (unit.hasMoved() || unit.getHp() == 0)
 				continue;
 			
 			// If the current unit was found, the target is the next one.


### PR DESCRIPTION
* Conditionally add "Next Unit" command to non-unit command menu
  * That condition being that there is a unit that is neither dead nor has moved
  * issue #108
* Dead units are no longer considered valid targets by the "select next unit" button
  * even if they died on the opponent's turn.