### PR TITLE
Bug fixing

### DIFF
--- a/src/net/fe/fightStage/Colossus.java
+++ b/src/net/fe/fightStage/Colossus.java
@@ -28,7 +28,7 @@ public class Colossus extends CombatTrigger{
 	 */
 	@Override
 	public boolean attempt(Unit user, int range, Unit opponent) {
-		return range == 1 && RNG.get() < user.getStats().skl/2;
+		return range == 1 && RNG.get() < user.getStats().skl/2 ;
 	}
 
 	/* (non-Javadoc)

--- a/src/net/fe/fightStage/Colossus.java
+++ b/src/net/fe/fightStage/Colossus.java
@@ -28,7 +28,7 @@ public class Colossus extends CombatTrigger{
 	 */
 	@Override
 	public boolean attempt(Unit user, int range, Unit opponent) {
-		return range == 1 && RNG.get() < user.getStats().skl/2 ;
+		return range == 1 && RNG.get() < user.getStats().skl/2;
 	}
 
 	/* (non-Javadoc)

--- a/src/net/fe/fightStage/FightStage.java
+++ b/src/net/fe/fightStage/FightStage.java
@@ -22,6 +22,7 @@ import net.fe.fightStage.anim.Platform;
 import net.fe.fightStage.anim.SkillIndicator;
 import net.fe.network.Message;
 import net.fe.overworldStage.Grid;
+import net.fe.overworldStage.Terrain;
 import net.fe.overworldStage.ClientOverworldStage;
 import net.fe.transition.FightOverworldTransition;
 import net.fe.unit.BattleStats;
@@ -215,8 +216,12 @@ public class FightStage extends Stage {
 		addEntity(new Platform(right.getTerrain(), false, range));
 		addEntity(new HUD(left, right, this));
 		addEntity(new HUD(right, left, this));
-		bg = FEResources.getTexture(right.getTerrain().toString().toLowerCase()
-				+ "_bg");
+		if(right.getTerrain() == Terrain.NONE)
+			bg = FEResources.getTexture(Terrain.PLAIN.toString().toLowerCase()
+					+ "_bg");
+		else
+			bg = FEResources.getTexture(right.getTerrain().toString().toLowerCase()
+					+ "_bg");
 
 		this.attackQ = attackQ;
 		this.returnTo = returnTo;

--- a/src/net/fe/fightStage/FightStage.java
+++ b/src/net/fe/fightStage/FightStage.java
@@ -217,11 +217,12 @@ public class FightStage extends Stage {
 		addEntity(new HUD(left, right, this));
 		addEntity(new HUD(right, left, this));
 		if(right.getTerrain() == Terrain.NONE)
-			bg = FEResources.getTexture(Terrain.PLAIN.toString().toLowerCase()
-					+ "_bg");
+			if(left.getTerrain() == Terrain.NONE)
+				bg = FEResources.getTexture(Terrain.PLAIN.toString().toLowerCase() + "_bg");
+			else
+				bg = FEResources.getTexture(left.getTerrain().toString().toLowerCase() + "_bg");
 		else
-			bg = FEResources.getTexture(right.getTerrain().toString().toLowerCase()
-					+ "_bg");
+			bg = FEResources.getTexture(right.getTerrain().toString().toLowerCase() + "_bg");
 
 		this.attackQ = attackQ;
 		this.returnTo = returnTo;

--- a/src/net/fe/fightStage/anim/Platform.java
+++ b/src/net/fe/fightStage/anim/Platform.java
@@ -31,24 +31,28 @@ public class Platform extends Entity {
 	public Platform(Terrain t, boolean left, int range) {
 		super(left ? 0 : FightStage.CENTRAL_AXIS, FightStage.FLOOR - 16);
 		this.left = left;
+		if(t != Terrain.NONE) {
 		String txtName = t.name().toLowerCase();
-		if(range > 1){
-			txtName += "_far";
+			if(range > 1){
+				txtName += "_far";
+			}
+			texture = FEResources.getTexture("platform_" + txtName);
+			renderDepth = FightStage.PLATFORM_DEPTH;
 		}
-		texture = FEResources.getTexture("platform_" + txtName);
-		renderDepth = FightStage.PLATFORM_DEPTH;
 	}
 
 	/* (non-Javadoc)
 	 * @see chu.engine.Entity#render()
 	 */
 	public void render() {
-		Transform t = new Transform();
-		if (!left) {
-			t.flipHorizontal();
+		if(texture != null) {
+			Transform t = new Transform();
+			if (!left) {
+				t.flipHorizontal();
+			}
+			Renderer.render(texture, 0, 0, 1, 1, x, y, x + 120, y + 40,
+					1, t);
 		}
-		Renderer.render(texture, 0, 0, 1, 1, x, y, x + 120, y + 40,
-				1, t);
 	}
 
 }

--- a/src/net/fe/fightStage/anim/Platform.java
+++ b/src/net/fe/fightStage/anim/Platform.java
@@ -32,10 +32,9 @@ public class Platform extends Entity {
 		super(left ? 0 : FightStage.CENTRAL_AXIS, FightStage.FLOOR - 16);
 		this.left = left;
 		if(t != Terrain.NONE) {
-		String txtName = t.name().toLowerCase();
-			if(range > 1){
+			String txtName = t.name().toLowerCase();
+			if(range > 1)
 				txtName += "_far";
-			}
 			texture = FEResources.getTexture("platform_" + txtName);
 			renderDepth = FightStage.PLATFORM_DEPTH;
 		}
@@ -47,11 +46,9 @@ public class Platform extends Entity {
 	public void render() {
 		if(texture != null) {
 			Transform t = new Transform();
-			if (!left) {
+			if (!left)
 				t.flipHorizontal();
-			}
-			Renderer.render(texture, 0, 0, 1, 1, x, y, x + 120, y + 40,
-					1, t);
+			Renderer.render(texture, 0, 0, 1, 1, x, y, x + 120, y + 40, 1, t);
 		}
 	}
 

--- a/src/net/fe/overworldStage/ClientOverworldStage.java
+++ b/src/net/fe/overworldStage/ClientOverworldStage.java
@@ -120,7 +120,7 @@ public class ClientOverworldStage extends OverworldStage {
 	public static final float CHAT_DEPTH = 0.3f;
 	
 	/** The Constant MENU_DEPTH. */
-	public static final float MENU_DEPTH = 0.2f;
+	public static final float MENU_DEPTH = 0.1f;
 	
 	/** The Constant CURSOR_DEPTH. */
 	public static final float CURSOR_DEPTH = 0.15f;

--- a/src/net/fe/unit/Unit.java
+++ b/src/net/fe/unit/Unit.java
@@ -983,7 +983,7 @@ public final class Unit extends GriddedEntity implements Serializable, DoNotDest
 	 * @param val the val
 	 */
 	public void setTempMod(String stat, int val) {
-		tempMods.put(stat, val);
+		tempMods.put(stat, (tempMods.containsKey(stat) ? tempMods.get(stat) : 0) + val);
 	}
 	
 	/**


### PR DESCRIPTION
Fixes some of the issues in the list that are easily resolved if anyone would spend 10 minutes to do it.

#69: Reduced the render depth of the menu from 0.2 to 0.1, this makes it above the cursor's depth (0.15)

#78: Added a dumb check for the "none" terrain. For the platform, if the terrain is none, it won't render anything. For the background of the fight stage, it attempts to find a non-none terrain based on the terrain of the two units. If both are none, it defaults to the plain's background.

#124: Changed how "tempMods" (Stat modifiers) interact with each other when multiple attempt are made to change a stat. Previously, the stat would be overwritten, retaining only the last one applied and causing the issue. Now, it adds values from different modifiers.

The fix for #124 should probably be done in a different manner. The way it works on this branch is fine but I believe it could probably combine two effects better. This fix delays the problem more than fixing it definitively.