### PR TITLE
Fix MoveCommand's use of `path`

### DIFF
--- a/src/net/fe/network/command/MoveCommand.java
+++ b/src/net/fe/network/command/MoveCommand.java
@@ -12,7 +12,7 @@ import net.fe.unit.Unit;
 
 public final class MoveCommand extends Command {
 	
-	private static final long serialVersionUID = 6468268282716381357L;
+	private static final long serialVersionUID = 2408000878615714583L;
 	
 	private final Node[] path;
 	
@@ -24,7 +24,7 @@ public final class MoveCommand extends Command {
 	public ArrayList<AttackRecord> applyServer(OverworldStage stage, Unit unit) {
 		
 		//TODO: validate
-		stage.grid.move(unit, unit.getXCoord() + path[path.length - 1].x, unit.getYCoord() + path[path.length - 1].y, false);
+		stage.grid.move(unit, path[path.length - 1].x, path[path.length - 1].y, false);
 		return null;
 	}
 	
@@ -35,7 +35,7 @@ public final class MoveCommand extends Command {
 			public void run() {
 				Path p = new Path();
 				p.setNodes(path);
-				stage.grid.move(unit, unit.getXCoord()+path[path.length - 1].x, unit.getYCoord()+path[path.length - 1].y, true);
+				stage.grid.move(unit, path[path.length - 1].x, path[path.length - 1].y, true);
 				unit.move(p, callback);
 				stage.includeInView(p.getAllNodes());
 			}
@@ -44,6 +44,6 @@ public final class MoveCommand extends Command {
 	
 	@Override
 	public String toString() {
-		return "Move[" + path[path.length - 1].x + "," + path[path.length - 1].y + "]";
+		return "Move[" + java.util.Arrays.toString(path) + "]";
 	}
 }


### PR DESCRIPTION
Fix a regression caused in b28b490a3ae0c77740ff74346a1dca8fb40365c6 that would result in either desynchronizations or the server to crash with IndexOutOfBounds errors. See also: https://github.com/eliatlarge/FEMultiPlayer-V2/pull/148#issuecomment-362795087
