### PR TITLE
Fixed the issue when giving rescued units

### DIFF
--- a/src/net/fe/network/command/GiveCommand.java
+++ b/src/net/fe/network/command/GiveCommand.java
@@ -1,0 +1,46 @@
+package net.fe.network.command;
+
+import java.util.ArrayList;
+
+import net.fe.fightStage.AttackRecord;
+import net.fe.overworldStage.ClientOverworldStage;
+import net.fe.overworldStage.OverworldStage;
+import net.fe.unit.Unit;
+import net.fe.unit.UnitIdentifier;
+
+public final class GiveCommand extends Command {
+	
+	private static final long serialVersionUID = 6468268282716381357L;
+	
+	private final UnitIdentifier destinationId;
+	
+	public GiveCommand(UnitIdentifier destinationId) {
+		this.destinationId = destinationId;
+	}
+	
+	@Override
+	public ArrayList<AttackRecord> applyServer(OverworldStage stage, Unit unit) {
+		
+		Unit destination = stage.getUnit(destinationId);
+		unit.give(destination); // throws IllegalStateException
+		return null;
+	}
+	
+	@Override
+	public Runnable applyClient(ClientOverworldStage stage, Unit unit, ArrayList<AttackRecord> attackRecords, Runnable callback) {
+		
+		return new Runnable() {
+			public void run() {
+				Unit destination = stage.getUnit(destinationId);
+				unit.give(destination);
+				stage.checkEndGame();
+				callback.run();
+			}
+		};
+	}
+	
+	@Override
+	public String toString() {
+		return "Take[" + destinationId + "]";
+	}
+}

--- a/src/net/fe/network/command/TakeCommand.java
+++ b/src/net/fe/network/command/TakeCommand.java
@@ -1,44 +1,38 @@
 package net.fe.network.command;
 
-import java.io.Serializable;
-import java.util.List;
 import java.util.ArrayList;
+
 import net.fe.fightStage.AttackRecord;
-import net.fe.overworldStage.OverworldStage;
 import net.fe.overworldStage.ClientOverworldStage;
-import net.fe.overworldStage.Path;
-import net.fe.overworldStage.Node;
-import net.fe.unit.UnitIdentifier;
+import net.fe.overworldStage.OverworldStage;
 import net.fe.unit.Unit;
-import net.fe.unit.Item;
-import net.fe.unit.RiseTome;
-import java.util.Optional;
+import net.fe.unit.UnitIdentifier;
 
 public final class TakeCommand extends Command {
 	
 	private static final long serialVersionUID = 6468268282716381357L;
 	
-	private final UnitIdentifier destinationId;
+	private final UnitIdentifier sourceId;
 	
-	public TakeCommand(UnitIdentifier destinationId) {
-		this.destinationId = destinationId;
+	public TakeCommand(UnitIdentifier sourceId) {
+		this.sourceId = sourceId;
 	}
 	
 	@Override
-	public ArrayList<AttackRecord> applyServer(OverworldStage stage, Unit unit) {
+	public ArrayList<AttackRecord> applyServer(OverworldStage stage, Unit destination) {
 		
-		Unit destination = stage.getUnit(destinationId);
-		unit.give(destination); // throws IllegalStateException
+		Unit source = stage.getUnit(sourceId);
+		source.give(destination); // throws IllegalStateException
 		return null;
 	}
 	
 	@Override
-	public Runnable applyClient(ClientOverworldStage stage, Unit unit, ArrayList<AttackRecord> attackRecords, Runnable callback) {
+	public Runnable applyClient(ClientOverworldStage stage, Unit destination, ArrayList<AttackRecord> attackRecords, Runnable callback) {
 		
 		return new Runnable() {
 			public void run() {
-				Unit destination = stage.getUnit(destinationId);
-				unit.give(destination);
+				Unit source = stage.getUnit(sourceId);
+				source.give(destination);
 				stage.checkEndGame();
 				callback.run();
 			}
@@ -47,6 +41,6 @@ public final class TakeCommand extends Command {
 	
 	@Override
 	public String toString() {
-		return "Take[" + destinationId + "]";
+		return "Take[" + sourceId + "]";
 	}
 }

--- a/src/net/fe/network/command/TakeCommand.java
+++ b/src/net/fe/network/command/TakeCommand.java
@@ -28,7 +28,7 @@ public final class TakeCommand extends Command {
 	public ArrayList<AttackRecord> applyServer(OverworldStage stage, Unit unit) {
 		
 		Unit other = stage.getUnit(otherId);
-		other.give(unit); // throws IllegalStateException
+		unit.give(other); // throws IllegalStateException
 		return null;
 	}
 	
@@ -38,7 +38,7 @@ public final class TakeCommand extends Command {
 		return new Runnable() {
 			public void run() {
 				Unit other = stage.getUnit(otherId);
-				other.give(unit);
+				unit.give(other);
 				stage.checkEndGame();
 				callback.run();
 			}

--- a/src/net/fe/network/command/TakeCommand.java
+++ b/src/net/fe/network/command/TakeCommand.java
@@ -18,17 +18,17 @@ public final class TakeCommand extends Command {
 	
 	private static final long serialVersionUID = 6468268282716381357L;
 	
-	private final UnitIdentifier otherId;
+	private final UnitIdentifier destinationId;
 	
-	public TakeCommand(UnitIdentifier otherId) {
-		this.otherId = otherId;
+	public TakeCommand(UnitIdentifier destinationId) {
+		this.destinationId = destinationId;
 	}
 	
 	@Override
 	public ArrayList<AttackRecord> applyServer(OverworldStage stage, Unit unit) {
 		
-		Unit other = stage.getUnit(otherId);
-		unit.give(other); // throws IllegalStateException
+		Unit destination = stage.getUnit(destinationId);
+		unit.give(destination); // throws IllegalStateException
 		return null;
 	}
 	
@@ -37,8 +37,8 @@ public final class TakeCommand extends Command {
 		
 		return new Runnable() {
 			public void run() {
-				Unit other = stage.getUnit(otherId);
-				unit.give(other);
+				Unit destination = stage.getUnit(destinationId);
+				unit.give(destination);
 				stage.checkEndGame();
 				callback.run();
 			}
@@ -47,6 +47,6 @@ public final class TakeCommand extends Command {
 	
 	@Override
 	public String toString() {
-		return "Take[" + otherId + "]";
+		return "Take[" + destinationId + "]";
 	}
 }

--- a/src/net/fe/overworldStage/context/GiveTarget.java
+++ b/src/net/fe/overworldStage/context/GiveTarget.java
@@ -1,6 +1,6 @@
 package net.fe.overworldStage.context;
 
-import net.fe.network.command.TakeCommand;
+import net.fe.network.command.GiveCommand;
 import net.fe.overworldStage.ClientOverworldStage;
 import net.fe.overworldStage.OverworldContext;
 import net.fe.overworldStage.SelectTargetContext;
@@ -42,7 +42,7 @@ public class GiveTarget extends SelectTargetContext {
 	 */
 	@Override
 	public void unitSelected(Unit u) {
-		stage.addCmd(new TakeCommand(new UnitIdentifier(u)));
+		stage.addCmd(new GiveCommand(new UnitIdentifier(u)));
 		stage.send();
 		unit.setMoved(true);
 		unit.give(u);


### PR DESCRIPTION
Direct followup to #168 
I did some testing. It seems the problem is that TakeCommand's source and destination units are swapped. In TakeCommand's applyServer/applyClient methods **other** refers to C the destination and **unit** refers to the source.

And so the game tries to give from the destination to the source, which obviously doesn't work. The fix is straightforward: just swap _other_ and _unit_