### PR TITLE
Fix eliwood javelin animation metadata

### DIFF
--- a/res/resources.json
+++ b/res/resources.json
@@ -521,8 +521,8 @@
 			"height":	86,
 			"frames":	11,
 			"columns":	4,
-			"offsetX":	179,
-			"offsetY":	66,
+			"offsetX":	178,
+			"offsetY":	69,
 			"freeze":	0,
 			"hitframes":[8],
 			"soundMap": [
@@ -535,21 +535,21 @@
 		{
 			"name":		"eliwood_javelin_critical",
 			"path":		"res/battle_anim/eliwood_javelin_critical.png",
-			"width":	220,
-			"height":	80,
-			"frames":	11,
+			"width":	218,
+			"height":	86,
+			"frames":	16,
 			"columns":	4,
-			"offsetX":	179,
-			"offsetY":	66,
+			"offsetX":	178,
+			"offsetY":	69,
 			"freeze":	0,
-			"hitframes":[9],
+			"hitframes":[14],
 			"soundMap": [
 				{
-					"frame":	4,
+					"frame":	6,
 					"sound":	"spin_short"
 				},
 				{
-					"frame":	8,
+					"frame":	12,
 					"sound":	"lance_throw"
 				}
 			]


### PR DESCRIPTION
Somewhat similar to the Ephriam one previously, except only the critical causes Eliwood to sink into the ground, and that the hit and crit were misaligned compared to the dodge. And that the crit seemed to be marked for the wrong framerate.

![image](https://user-images.githubusercontent.com/11641215/42730829-f18ba21e-87cd-11e8-865b-af2fa99bdae3.png)
