### PR TITLE
Automatic reconnection on disconnection

### DIFF
--- a/src/net/fe/network/Client.java
+++ b/src/net/fe/network/Client.java
@@ -101,7 +101,8 @@ public class Client {
 					close();
 				} catch (Throwable e) {
 					close(); // Close just to be sure.
-					if(shouldReconnect)
+					long time = System.currentTimeMillis();
+					while(shouldReconnect && !open && System.currentTimeMillis() - time <= Server.TIMEOUT)
 						connect(ip, port);
 					logger.throwing("ClientNetworkingReader", "run", e);
 				}

--- a/src/net/fe/network/Client.java
+++ b/src/net/fe/network/Client.java
@@ -69,6 +69,7 @@ public class Client {
 	
 	/** The id. */
 	byte id;
+	private long token;
 	
 	/** The messages. Should only operate on if the monitor to messagesLock is held */
 	public final CopyOnWriteArrayList<Message> messages;
@@ -137,6 +138,7 @@ public class Client {
 			if (message2.hashes.equals(ClientInit.Hashes.pullFromStatics(message2.session.getMap()))) {
 				this.id = message2.clientID;
 				this.session = message2.session;
+				this.token = message2.token;
 				FEMultiplayer.getLocalPlayer().setClientID(message2.clientID);
 				if(id >= 2) {
 					FEMultiplayer.getLocalPlayer().getParty().setColor(Party.TEAM_RED);

--- a/src/net/fe/network/Client.java
+++ b/src/net/fe/network/Client.java
@@ -4,23 +4,22 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
-import java.util.ArrayList;
+import java.time.LocalDateTime;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Logger;
-import java.time.LocalDateTime;
 
+import org.newdawn.slick.Color;
+
+import chu.engine.menu.Notification;
 import net.fe.FEMultiplayer;
 import net.fe.Party;
-import net.fe.Player;
 import net.fe.Session;
 import net.fe.network.message.ClientInit;
 import net.fe.network.message.EndGame;
 import net.fe.network.message.JoinLobby;
 import net.fe.network.message.KickMessage;
 import net.fe.network.message.QuitMessage;
-
-import org.newdawn.slick.Color;
-import chu.engine.menu.Notification;
+import net.fe.network.message.RejoinMessage;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -60,6 +59,7 @@ public class Client {
 	
 	/** The open. */
 	private boolean open = false;
+	private boolean initialized = false;
 	
 	/** The close requested. */
 	private boolean closeRequested = false;
@@ -70,6 +70,8 @@ public class Client {
 	/** The id. */
 	byte id;
 	private long token;
+	private long lastTimestamp = -1;
+	private boolean shouldReconnect = true;
 	
 	/** The messages. Should only operate on if the monitor to messagesLock is held */
 	public final CopyOnWriteArrayList<Message> messages;
@@ -87,37 +89,25 @@ public class Client {
 		messages = new CopyOnWriteArrayList<Message>();
 		session = new Session();
 		messagesLock = new Object();
-		try {
-			logger.info("CLIENT: Connecting to server: "+ip+":"+port);
-			serverSocket = new Socket(ip, port);
-			logger.info("CLIENT: Successfully connected!");
-			out = new ObjectOutputStream(serverSocket.getOutputStream());
-			out.flush();
-			in = new ObjectInputStream(serverSocket.getInputStream());
-			logger.info("CLIENT: I/O streams initialized");
-			open = true;
-			serverIn = new Thread(new Runnable() {
-				public void run() {
-					try {
-						Message message;
-						while((message = (Message)in.readObject()) != null) {
-							logger.info("CLIENT: Read " + message);
-							processInput(message);
-						}
-						in.close();
-						out.close();
-						serverSocket.close();
-					} catch (IOException e) {
-						logger.warning("CLIENT: EXIT");
-						logger.throwing("ClientNetworkingReader", "run", e);
-					} catch (ClassNotFoundException e) {
-						logger.throwing("ClientNetworkingReader", "run", e);
+		connect(ip, port);
+		serverIn = new Thread(() -> {
+			while(open) {
+				try {
+					Message message;
+					while((message = (Message)in.readObject()) != null) {
+						logger.info("CLIENT: Read " + message);
+						processInput(message);
 					}
+					close();
+				} catch (Throwable e) {
+					close(); // Close just to be sure.
+					if(shouldReconnect)
+						connect(ip, port);
+					logger.throwing("ClientNetworkingReader", "run", e);
 				}
-			}, "ClientNetworkingReader");
-		} catch (IOException e) {
-			logger.throwing("Client", "<init>", e);
-		}
+			}
+			close();
+		}, "ClientNetworkingReader");
 	}
 	
 	/**
@@ -127,6 +117,21 @@ public class Client {
 		serverIn.start();
 	}
 	
+	private void connect(String ip, int port) {
+		try {
+			logger.info("CLIENT: Connecting to server: "+ip+":"+port);
+			serverSocket = new Socket(ip, port);
+			logger.info("CLIENT: Successfully connected!");
+			out = new ObjectOutputStream(serverSocket.getOutputStream());
+			out.flush();
+			in = new ObjectInputStream(serverSocket.getInputStream());
+			logger.info("CLIENT: I/O streams initialized");
+			open = true;
+		} catch (IOException e) {
+			logger.throwing("Client", "<init>", e);
+		}
+	}
+	
 	/**
 	 * Process input.
 	 *
@@ -134,27 +139,31 @@ public class Client {
 	 */
 	private void processInput(Message message) {
 		if(message instanceof ClientInit) {
-			ClientInit message2 = (ClientInit) message;
-			if (message2.hashes.equals(ClientInit.Hashes.pullFromStatics(message2.session.getMap()))) {
-				this.id = message2.clientID;
-				this.session = message2.session;
-				this.token = message2.token;
-				FEMultiplayer.getLocalPlayer().setClientID(message2.clientID);
-				if(id >= 2) {
-					FEMultiplayer.getLocalPlayer().getParty().setColor(Party.TEAM_RED);
-				}
-				logger.info("CLIENT: Recieved ID "+id+" from server");
-				// Send a join lobby request
-				sendMessage(new JoinLobby(id, FEMultiplayer.getLocalPlayer().getName()));
+			if(initialized) {
+				logger.info("CLIENT: Reconnecting to the server");
+				sendMessage(new RejoinMessage(lastTimestamp, token));
 			} else {
-				logger.info("CLIENT: Mismatched hashes:" +
-						"\n\tServer: " + message2.hashes +
-						"\n\tClient: " + ClientInit.Hashes.pullFromStatics(message2.session.getMap()));
-				this.id = message2.clientID;
-				this.quit();
-				FEMultiplayer.setCurrentStage(FEMultiplayer.connect);
-				FEMultiplayer.connect.addEntity(new Notification(
-					180, 120, "default_med", "ERROR: Server and Client versions don't match", 5f, new Color(255, 100, 100), 0f));
+				ClientInit message2 = (ClientInit) message;
+				if (message2.hashes.equals(ClientInit.Hashes.pullFromStatics(message2.session.getMap()))) {
+					this.id = message2.clientID;
+					this.session = message2.session;
+					this.token = message2.token;
+					FEMultiplayer.getLocalPlayer().setClientID(message2.clientID);
+					if(id >= 2) {
+						FEMultiplayer.getLocalPlayer().getParty().setColor(Party.TEAM_RED);
+					}
+					logger.info("CLIENT: Recieved ID "+id+" from server");
+					// Send a join lobby request
+					sendMessage(new JoinLobby(id, FEMultiplayer.getLocalPlayer().getName()));
+					initialized = true;
+				} else {
+					logger.info("CLIENT: Mismatched hashes:" +
+							"\n\tServer: " + message2.hashes +
+							"\n\tClient: " + ClientInit.Hashes.pullFromStatics(message2.session.getMap()));
+					this.id = message2.clientID;
+					this.quit();
+					resetToLobby("ERROR: Server and Client versions don't match");
+				}
 			}
 		} else if (message instanceof QuitMessage) {
 			if(message.origin == id && closeRequested) {
@@ -163,10 +172,9 @@ public class Client {
 		} else if (message instanceof KickMessage) {
 			KickMessage kick = (KickMessage) message;
 			if (kick.player == id) {
+				shouldReconnect = false;
 				close();
-				FEMultiplayer.setCurrentStage(FEMultiplayer.connect);
-				FEMultiplayer.connect.addEntity(new Notification(
-					180, 120, "default_med", "KICKED: " + kick.reason, 5f, new Color(255, 100, 100), 0f));
+				resetToLobby("KICKED: " + kick.reason);
 			}
 		} else if(message instanceof EndGame) {
 			winner = (byte) ((EndGame)message).winner;
@@ -200,6 +208,7 @@ public class Client {
 		sendMessage(new QuitMessage(id));
 		// simple security to prevent clients closing other clients
 		closeRequested = true;
+		shouldReconnect = false;
 	}
 	
 	/**
@@ -216,6 +225,15 @@ public class Client {
 			logger.severe("CLIENT Unable to send message: ["+message.toString()+"]");
 			logger.throwing("Client", "sendMessage", e);
 		}
+	}
+	
+	private void resetToLobby() {
+		FEMultiplayer.setCurrentStage(FEMultiplayer.connect);
+	}
+	
+	private void resetToLobby(String message) {
+		resetToLobby();
+		FEMultiplayer.connect.addEntity(new Notification(180, 120, "default_med", message, 5f, new Color(255, 100, 100), 0f));
 	}
 	
 	/**

--- a/src/net/fe/network/FEServer.java
+++ b/src/net/fe/network/FEServer.java
@@ -91,6 +91,7 @@ public class FEServer extends Game {
 				} catch (InterruptedException e) {
 					// No, really. Has there ever been a meaningful response to an InterruptedException?
 				}
+				server.timeoutClients();
 				messages.addAll(server.messages);
 				for (Message message : messages) {
 					if (message instanceof JoinTeam || message instanceof ReadyMessage) {

--- a/src/net/fe/network/FEServer.java
+++ b/src/net/fe/network/FEServer.java
@@ -171,12 +171,16 @@ public class FEServer extends Game {
 	 */
 	public static void resetToLobbyAndKickPlayers() {
 		resetToLobby();
+		kickPlayers("Reseting server");
+	}
+	
+	public static void kickPlayers(String reason) {
 		ArrayList<Byte> ids = new ArrayList<>();
 		for (Player p : getPlayers().values())
 			ids.add(p.getID());
 		synchronized (server.messagesLock) {
 			for (byte i : ids) {
-				final KickMessage kick = new KickMessage((byte) 0, i, "Reseting server");
+				final KickMessage kick = new KickMessage((byte) 0, i, reason);
 				server.broadcastMessage(kick);
 				server.messages.add(kick);
 			}

--- a/src/net/fe/network/Message.java
+++ b/src/net/fe/network/Message.java
@@ -13,12 +13,13 @@ public abstract class Message implements Serializable {
 	
 	/** The origin. */
 	public byte origin;
+	private long timestamp;
 	
 	/**
 	 * Instantiates a new message.
 	 */
 	public Message() {
-		
+		this((byte) 0);
 	}
 	
 	/**
@@ -28,6 +29,7 @@ public abstract class Message implements Serializable {
 	 */
 	public Message(byte origin) {
 		this.origin = origin;
+		timestamp = System.currentTimeMillis();
 	}
 	
 	/* (non-Javadoc)
@@ -37,5 +39,13 @@ public abstract class Message implements Serializable {
 		String classname = getClass().getSimpleName().toUpperCase();
 		classname.replaceAll("MESSAGE", "");
 		return origin + " " + getClass().getSimpleName().toUpperCase() + "::";
+	}
+
+	public void setTimestamp(long timestamp) {
+		this.timestamp = timestamp;
+	}
+	
+	public long getTimestamp() {
+		return timestamp;
 	}
 }

--- a/src/net/fe/network/Server.java
+++ b/src/net/fe/network/Server.java
@@ -57,6 +57,8 @@ public final class Server {
 	/** Contains the next playerId to be used when a player joins the server */
 	private byte nextPlayerId = 1;
 	
+	private ArrayList<Message> broadcastedMessages = new ArrayList<>();
+	
 	/**
 	 * Instantiates a new server.
 	 */
@@ -98,6 +100,8 @@ public final class Server {
 	 */
 	public void broadcastMessage(Message message) {
 		logger.finer("[SEND]" + message);
+		message.setTimestamp(System.currentTimeMillis());
+		broadcastedMessages.add(message);
 		for(ServerListener out : clients) {
 			out.sendMessage(message);
 		}

--- a/src/net/fe/network/Server.java
+++ b/src/net/fe/network/Server.java
@@ -169,4 +169,8 @@ public final class Server {
 		}
 		return false;
 	}
+	
+	public Message[] getBroadcastedMessages() {
+		return broadcastedMessages.toArray(new Message[0]);
+	}
 }

--- a/src/net/fe/network/Server.java
+++ b/src/net/fe/network/Server.java
@@ -37,7 +37,7 @@ public final class Server {
 		}
 	}
 	
-	private static final long TIMEOUT = 30000; // 30 seconds
+	public static final long TIMEOUT = 30000; // 30 seconds
 	
 	/** The server socket. */
 	private ServerSocket serverSocket;

--- a/src/net/fe/network/message/ClientInit.java
+++ b/src/net/fe/network/message/ClientInit.java
@@ -15,6 +15,7 @@ public final class ClientInit extends Message {
 	
 	/** The id assigned to the client */
 	public final byte clientID;
+	public final long token;
 	
 	/** Session data */
 	public final Session session;
@@ -29,10 +30,11 @@ public final class ClientInit extends Message {
 	 * @param clientID the client id
 	 * @param s the s
 	 */
-	public ClientInit(byte origin, byte clientID, Session s) {
+	public ClientInit(byte origin, byte clientID, Session s, long token) {
 		super(origin);
 		this.clientID = clientID;
 		this.session = s;
+		this.token = token;
 		this.hashes = Hashes.pullFromStatics(session.getMap());
 	}
 	

--- a/src/net/fe/network/message/RejoinMessage.java
+++ b/src/net/fe/network/message/RejoinMessage.java
@@ -1,0 +1,24 @@
+package net.fe.network.message;
+
+import net.fe.network.Message;
+
+public class RejoinMessage extends Message {
+
+	private static final long serialVersionUID = 6897797603372162386L;
+	
+	private long lastTimestamp;
+	private long token;
+	
+	public RejoinMessage(long lastTimestamp, long token) {
+		this.lastTimestamp = lastTimestamp;
+		this.token = token;
+	}
+
+	public long getLastTimestamp() {
+		return lastTimestamp;
+	}
+
+	public long getToken() {
+		return token;
+	}
+}

--- a/src/net/fe/network/serverui/FEServerFrame.java
+++ b/src/net/fe/network/serverui/FEServerFrame.java
@@ -56,6 +56,7 @@ public class FEServerFrame extends JFrame {
 				feserver.init();
 				feserver.loop();
 			} catch (Throwable e) {
+				FEServer.kickPlayers("Server crashed");
 				logError(e);
 			}
 		}).start();

--- a/src/net/fe/overworldStage/OverworldStage.java
+++ b/src/net/fe/overworldStage/OverworldStage.java
@@ -27,6 +27,7 @@ import net.fe.network.Message;
 import net.fe.network.message.CommandMessage;
 import net.fe.network.message.EndGame;
 import net.fe.network.message.EndTurn;
+import net.fe.network.message.KickMessage;
 import net.fe.network.message.QuitMessage;
 import net.fe.overworldStage.objective.Objective;
 import net.fe.rng.RNG;
@@ -279,7 +280,7 @@ public class OverworldStage extends Stage {
 					doStartTurn();
 				}
 			}
-			else if(message instanceof QuitMessage) {
+			else if(message instanceof QuitMessage || message instanceof KickMessage) {
 				this.checkEndGame();
 			}
 			else if(message instanceof EndGame) {


### PR DESCRIPTION
When an unexpected disconnection occurs (i.e. the ServerListener or the Client thread runs into an exception/error), instead of simply giving up, the game will try re-establishing the connection by creating a new socket. If it succeeds, the game will continue running as normal and the server will send the messages this client might've missed. If it fails, then the server will kick that player after a set delay (Server.TIMEOUT, currently set to 30 seconds).

Because of the difficulty to actually test these changes, I've used the [wellme:reconnect-test](https://github.com/wellme/FEMultiPlayer-V2/tree/reconnect-test) branch to simulate connection drops.

This could be further developed to allow late joins (it's just the reconnection-and-send-missed-messages-if-any procedure, but with the server sending _all_ messages since game start), the problem with that would be that it'd not really be a "late join", more like playing the entirety of the game up to the point of connection in fast-forward.

Content:
- Reconnection on exceptions from sockets/streams.
- Server-wide kick when the server crashes (for whatever reason).
- (Untested) Client quit on client crash (Actually just an unexpected disconnection into lack of reconnection, which makes the server kick this specific player).

Known issues:

- The server message list is never cleared, as such, it will take more and more memory to maintain. This is a potential problem if the server runs continuously for a long period of time. This shouldn't really happen right now, as players seldom want to play with the same Session configuration for extended periods of time. As such, I'm not going to fix this unless there's a bigger issue I'm not seeing.
- I've done my best with the synchronization of the server. That said, I have no idea how good of a job I've done.
- While there were still bugs laying around (that I could find), it would sometimes happen that the client would rapidly try reconnecting to the server, resulting in the server running out of valid client IDs (In fact, every time a client reconnects, it uses one of the 127 valid IDs up). That shouldn't happen anymore, it's more of a warning that the 7-bit unique client ID might be in need of some expansion.

This fixes @SapphireTactician's broken pipe issues and #40, from what I've read of that thread.