### PR TITLE
Change Sol Katti's effective multiplier to ×2

### DIFF
--- a/src/net/fe/fightStage/CombatCalculator.java
+++ b/src/net/fe/fightStage/CombatCalculator.java
@@ -385,22 +385,26 @@ public class CombatCalculator {
 		// run preAttack triggers that are allowed to be shown in the preview
 		for (CombatTrigger t : a.getTriggers())
 			if (((t.turnToRun & CombatTrigger.SHOW_IN_PREVIEW) != 0) &&	((t.turnToRun & CombatTrigger.YOUR_TURN_PRE) != 0))
-				t.runPreAttack(null, a, d);
+				if (t.attempt(a, -1, d, new net.fe.rng.NullRNG()))
+					t.runPreAttack(null, a, d);
 		
 		for (CombatTrigger t : d.getTriggers())
 			if (((t.turnToRun & CombatTrigger.SHOW_IN_PREVIEW) != 0) &&	((t.turnToRun & CombatTrigger.ENEMY_TURN_PRE) != 0))
-				t.runPreAttack(null, a, d);
+				if (t.attempt(a, -1, d, new net.fe.rng.NullRNG()))
+					t.runPreAttack(null, a, d);
 		
 		int damage = CombatCalculator.calculateBaseDamage(a, d);
 
 		// Run combat mods that are allowed to occur in the preview
 		for (CombatTrigger t : a.getTriggers())
 			if (((t.turnToRun & CombatTrigger.SHOW_IN_PREVIEW) != 0) && ((t.turnToRun & CombatTrigger.YOUR_TURN_MOD) != 0))
-				damage = t.runDamageMod(a, d, damage);
+				if (t.attempt(a, -1, d, new net.fe.rng.NullRNG()))
+					damage = t.runDamageMod(a, d, damage);
 		
 		for (CombatTrigger t : d.getTriggers())
 			if (((t.turnToRun & CombatTrigger.SHOW_IN_PREVIEW) != 0) && ((t.turnToRun & CombatTrigger.ENEMY_TURN_MOD) != 0))
-				damage = t.runDamageMod(a, d, damage);
+				if (t.attempt(a, -1, d, new net.fe.rng.NullRNG()))
+					damage = t.runDamageMod(a, d, damage);
 
 		damage = limit(0, 100, damage);
 		int hit = limit(0, 100, hitRate(a, d));

--- a/src/net/fe/fightStage/CombatCalculator.java
+++ b/src/net/fe/fightStage/CombatCalculator.java
@@ -344,17 +344,15 @@ public class CombatCalculator {
 	 * @return the base damage
 	 */
 	public static int calculateBaseDamage(Unit a, Unit d){
-		boolean effective = a.getWeapon().effective.contains(d.noGenderName());
-		
 		int base;
 		if (a.getWeapon().isMagic()) {
 			base = a.getStats().mag
 					+ (a.getWeapon().mt + a.getWeapon().triMod(d.getWeapon()))
-					* (effective ? 3: 1) - d.getStats().res;
+					- d.getStats().res;
 		} else {
 			base = a.getStats().str
 					+ (a.getWeapon().mt + a.getWeapon().triMod(d.getWeapon()))
-					* (effective? 3:1) - d.getStats().def;
+					- d.getStats().def;
 		}
 		
 		return Math.max(base, 0);

--- a/src/net/fe/fightStage/Effective.java
+++ b/src/net/fe/fightStage/Effective.java
@@ -7,11 +7,13 @@ import net.fe.rng.RNG;
 import net.fe.unit.Unit;
 
 /**
- * Multiplies a weapon's str by a given amount
+ * Multiplies a weapon's mt by a given amount when fighting a unit with a
+ * specified other class
  * 
  * Implemented by increasing the user's mag and str by a multiple of the
  * equipped unit's weapon's might
  * 
+ * Condition: enemy class in contained in this's list of classes
  * Chance: 100%
  */
 public final class Effective extends CombatTrigger{
@@ -23,6 +25,7 @@ public final class Effective extends CombatTrigger{
 	public final List<String> classes;
 	
 	/**
+	 * The parameters match this's public fields, modulo some defensive copying
 	 */
 	public Effective(int multiplier, List<String> classes){
 		super(NO_NAME_MOD, YOUR_TURN_PRE | SHOW_IN_PREVIEW);
@@ -46,7 +49,22 @@ public final class Effective extends CombatTrigger{
 		return true;
 	}
 	
+	@Override
 	public CombatTrigger getCopy(){
 		return new Effective(this.multiplier, this.classes);
 	}
+	
+	@Override
+	protected boolean canEquals(Object other) {
+		return other instanceof Effective;
+	}
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof Effective &&
+			((Effective) other).canEquals(this) &&
+			((Effective) other).multiplier == this.multiplier &&
+			((Effective) other).classes.equals(this.classes);
+	}
+	@Override public int hashCode() { return this.getName().hashCode() * 31 + multiplier * 31 + this.classes.hashCode(); }
+	@Override public String toString() { return this.getName() + " x" + multiplier + " " + this.classes.toString(); }
 }

--- a/src/net/fe/fightStage/Effective.java
+++ b/src/net/fe/fightStage/Effective.java
@@ -1,0 +1,52 @@
+package net.fe.fightStage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.fe.rng.RNG;
+import net.fe.unit.Unit;
+
+/**
+ * Multiplies a weapon's str by a given amount
+ * 
+ * Implemented by increasing the user's mag and str by a multiple of the
+ * equipped unit's weapon's might
+ * 
+ * Chance: 100%
+ */
+public final class Effective extends CombatTrigger{
+	private static final long serialVersionUID = 1L;
+	
+	/** The might multiplier */
+	public final int multiplier;
+	/** The unit classes that this triggers against */
+	public final List<String> classes;
+	
+	/**
+	 */
+	public Effective(int multiplier, List<String> classes){
+		super(NO_NAME_MOD, YOUR_TURN_PRE | SHOW_IN_PREVIEW);
+		this.multiplier = multiplier;
+		this.classes = java.util.Collections.unmodifiableList(new ArrayList<String>(classes));
+	}
+	
+	@Override
+	public boolean attempt(Unit user, int range, Unit opponent, RNG rng) {
+		return classes.contains(opponent.noGenderName());
+	}
+
+	@Override
+	public boolean runPreAttack(CombatCalculator stage, Unit a, Unit d) {
+		// Apply the triangle modifier before multiplying weapon mt 
+		final int effectiveMt = (a.getWeapon().mt + a.getWeapon().triMod(d.getWeapon()));
+		final int delta = effectiveMt * (multiplier - 1);
+		
+		a.setTempMod("Str", delta);
+		a.setTempMod("Mag", delta);
+		return true;
+	}
+	
+	public CombatTrigger getCopy(){
+		return new Effective(this.multiplier, this.classes);
+	}
+}

--- a/src/net/fe/overworldStage/BattlePreview.java
+++ b/src/net/fe/overworldStage/BattlePreview.java
@@ -11,6 +11,8 @@ import chu.engine.anim.Transform;
 import net.fe.FEResources;
 import net.fe.fightStage.CombatCalculator;
 import net.fe.fightStage.CombatCalculator.MainBattleStats;
+import net.fe.fightStage.CombatTrigger;
+import net.fe.fightStage.Effective;
 import net.fe.fightStage.FightStage;
 import net.fe.unit.ItemDisplay;
 import net.fe.unit.Unit;
@@ -119,7 +121,12 @@ public class BattlePreview extends Entity {
 		if(attacker.getWeapon().name.contains("Brave"))
 			aMult*=2;
 		
-		aEffective = attacker.getWeapon().effective.contains(defender.noGenderName());
+		for (CombatTrigger t : attacker.getTriggers()) {
+			aEffective = aEffective || (
+				t instanceof Effective &&
+					t.attempt(attacker, range, defender, new net.fe.rng.NullRNG())
+			);
+		}
 		
 		//defender determination
 		stats = CombatCalculator.calculatePreviewStats(defender, attacker, CombatCalculator.shouldAttack(defender, attacker, defender.getWeapon(), range));
@@ -137,7 +144,12 @@ public class BattlePreview extends Entity {
 			if(defender.getWeapon().name.contains("Brave"))
 				dMult*=2;
 			
-			dEffective = defender.getWeapon().effective.contains(attacker.noGenderName());
+			for (CombatTrigger t : defender.getTriggers()) {
+				dEffective = dEffective || (
+					t instanceof Effective &&
+						t.attempt(defender, range, attacker, new net.fe.rng.NullRNG())
+				);
+			}
 		}
 		
 		// Borders

--- a/src/net/fe/unit/ItemDetailsText.java
+++ b/src/net/fe/unit/ItemDetailsText.java
@@ -8,6 +8,7 @@ import chu.engine.anim.Renderer;
 import net.fe.fightStage.Brave;
 import net.fe.fightStage.CombatTrigger;
 import net.fe.fightStage.EclipseSix;
+import net.fe.fightStage.Effective;
 import net.fe.fightStage.LunaPlus;
 import net.fe.fightStage.Nosferatu;
 import net.fe.fightStage.CrossBow;
@@ -81,17 +82,43 @@ public final class ItemDetailsText extends Entity{
 		if(wep.name.contains("Kill") || wep.name.equals("Wo Dao")){
 			sb.append("Has a high critical rate. ");
 		}
-		if(wep.getTriggers().contains(new CrossBow())) {
-			sb.append("Ignores user's Str. ");
-		}
-		if(wep.getTriggers().contains(new EclipseSix())) {
-			sb.append("Reduces enemy HP to 1. ");
-		}
-		if(wep.getTriggers().contains(new LunaPlus())) {
-			sb.append("Ignores enemy resistance. ");
-		}
-		if(wep.getTriggers().contains(new Nosferatu())) {
-			sb.append("Restores user HP by half of damage dealt. ");
+		for (CombatTrigger t : wep.getTriggers()) {
+			if (t instanceof CrossBow) {
+				sb.append("Ignores user's Str. ");
+			}
+			if (t instanceof EclipseSix) {
+				sb.append("Reduces enemy HP to 1. ");
+			}
+			if (t instanceof LunaPlus) {
+				sb.append("Ignores enemy resistance. ");
+			}
+			if (t instanceof Nosferatu) {
+				sb.append("Restores user HP by half of damage dealt. ");
+			}
+			if (t instanceof Effective) {
+				java.util.List<String> classes = ((Effective) t).classes;
+				ArrayList<String> eff = new ArrayList<String>();
+				if(classes.contains("General")){
+					eff.add("armored");
+				}
+				if(classes.contains("Valkyrie")){
+					eff.add("mounted");
+				}
+				if(classes.contains("Falconknight")){
+					eff.add("flying");
+				}
+				String effText = "";
+				for(String s: eff){
+					effText += ", " + s;
+				}
+				if (2 == ((Effective) t).multiplier) {
+					sb.append("Somewhat effective against " + effText.substring(2) + " units. ");
+				} else if (3 == ((Effective) t).multiplier) {
+					sb.append("Effective against " + effText.substring(2) + " units. ");
+				} else {
+					sb.append("Effective (x" + ((Effective) t).multiplier + ") against " + effText.substring(2) + " units. ");
+				}
+			}
 		}
 		if(wep.getCost() == 10000){
 			sb.append("A legendary weapon. ");
@@ -105,25 +132,6 @@ public final class ItemDetailsText extends Entity{
 		for(String stat: wep.modifiers.toMap().keySet()){
 			if(wep.modifiers.toMap().get(stat) != 0){
 				sb.append(stat + "+" + wep.modifiers.toMap().get(stat) + ". ");
-			}
-		}
-		if(wep.effective.size() != 0){
-			ArrayList<String> eff = new ArrayList<String>();
-			if(wep.effective.contains("General")){
-				eff.add("armored");
-			}
-			if(wep.effective.contains("Valkyrie")){
-				eff.add("mounted");
-			}
-			if(wep.effective.contains("Falconknight")){
-				eff.add("flying");
-			}
-			String effText = "";
-			for(String s: eff){
-				effText += ", " + s;
-			}
-			if(effText.length() != 0) {
-				sb.append("Effective against " + effText.substring(2) + " units. ");
 			}
 		}
 		

--- a/src/net/fe/unit/Weapon.java
+++ b/src/net/fe/unit/Weapon.java
@@ -184,7 +184,8 @@ public final class Weapon extends Item {
 			triggers.add(new CrossBow());
 		}
 		if (this.effective.size() != 0) {
-			triggers.add(new Effective(3, this.effective));
+			final int multiplier = (name.equals("Sol Katti") ? 2 : 3);
+			triggers.add(new Effective(multiplier, this.effective));
 		}
 		return triggers;
 	}

--- a/src/net/fe/unit/Weapon.java
+++ b/src/net/fe/unit/Weapon.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 import net.fe.fightStage.Brave;
 import net.fe.fightStage.CombatTrigger;
 import net.fe.fightStage.EclipseSix;
+import net.fe.fightStage.Effective;
 import net.fe.fightStage.LunaPlus;
 import net.fe.fightStage.Nosferatu;
 import net.fe.fightStage.CrossBow;
@@ -32,7 +33,7 @@ public final class Weapon extends Item {
 	public final Type type;
 	
 	/** The effective. */
-	public final List<String> effective;
+	private final List<String> effective;
 	
 	/** The pref. */
 	public final String pref;
@@ -181,6 +182,9 @@ public final class Weapon extends Item {
 			triggers.add(new EclipseSix());
 		} else if (type == Type.CROSSBOW) {
 			triggers.add(new CrossBow());
+		}
+		if (this.effective.size() != 0) {
+			triggers.add(new Effective(3, this.effective));
 		}
 		return triggers;
 	}

--- a/test/net/fe/fightStage/CombatCalculatorTest.java
+++ b/test/net/fe/fightStage/CombatCalculatorTest.java
@@ -146,6 +146,60 @@ public final class CombatCalculatorTest {
 		assertEquals(13, CombatCalculator.calculatePreviewStats(left, right, true).damage);
 	}
 	
+	@Test
+	public void calculatePreviewDamage_EffectiveDamage() {
+		Weapon effectiveWeapon = new Weapon(
+			"fork", 1, 0, 0,
+			Weapon.Type.AXE, 5, 0, 0, (s) -> java.util.Arrays.asList(1),
+			new Statistics(), java.util.Arrays.asList("Phantom"), null
+		);
+		
+		Statistics leftVals = new Statistics();
+		leftVals = leftVals.copy("HP", 20);
+		leftVals = leftVals.copy("Str", 2);
+		Unit left = new Unit("left", Class.createClass("Phantom"), '-', leftVals, leftVals);
+		left.equip(effectiveWeapon);
+		
+		Statistics rightVals = new Statistics();
+		rightVals = rightVals.copy("HP", 20);
+		rightVals = rightVals.copy("Def", 3);
+		Unit right = new Unit("right", Class.createClass("Phantom"), '-', rightVals, rightVals);
+		
+		assertEquals(2 + 5 * 3 - 3, CombatCalculator.calculatePreviewStats(left, right, true).damage);
+	}
+	
+	@Test
+	public void calculatePreviewDamage_EffectiveTriangleDamage() {
+		Weapon effectiveWeapon = new Weapon(
+			"fork", 1, 0, 0,
+			Weapon.Type.AXE, 5, 0, 0, (s) -> java.util.Arrays.asList(1),
+			new Statistics(), java.util.Arrays.asList("Paladin"), null
+		);
+		
+		Statistics leftVals = new Statistics();
+		leftVals = leftVals.copy("HP", 20);
+		leftVals = leftVals.copy("Str", 2);
+		Unit left = new Unit("left", Class.createClass("Phantom"), '-', leftVals, leftVals);
+		left.equip(effectiveWeapon);
+		
+		Statistics rightVals = new Statistics();
+		rightVals = rightVals.copy("HP", 20);
+		rightVals = rightVals.copy("Def", 3);
+		Unit right = new Unit("right", Class.createClass("Paladin"), '-', rightVals, rightVals);
+		
+		right.equip(createWeapon(Weapon.Type.AXE, 8));
+		int normalDamage = CombatCalculator.calculatePreviewStats(left, right, true).damage;
+		
+		right.equip(createWeapon(Weapon.Type.LANCE, 8));
+		int wtaDamage = CombatCalculator.calculatePreviewStats(left, right, true).damage;
+		
+		right.equip(createWeapon(Weapon.Type.SWORD, 8));
+		int wtdDamage = CombatCalculator.calculatePreviewStats(left, right, true).damage;
+		
+		assertEquals(3, wtaDamage - normalDamage);
+		assertEquals(3, normalDamage - wtdDamage);
+	}
+	
 	
 	private Weapon createWeapon(Weapon.Type type, int might) {
 		

--- a/test/net/fe/fightStage/CombatCalculatorTest.java
+++ b/test/net/fe/fightStage/CombatCalculatorTest.java
@@ -169,6 +169,28 @@ public final class CombatCalculatorTest {
 	}
 	
 	@Test
+	public void calculatePreviewDamage_NotEffectiveDamage() {
+		Weapon effectiveWeapon = new Weapon(
+			"fork", 1, 0, 0,
+			Weapon.Type.AXE, 5, 0, 0, (s) -> java.util.Arrays.asList(1),
+			new Statistics(), java.util.Arrays.asList("Paladin"), null
+		);
+		
+		Statistics leftVals = new Statistics();
+		leftVals = leftVals.copy("HP", 20);
+		leftVals = leftVals.copy("Str", 2);
+		Unit left = new Unit("left", Class.createClass("Phantom"), '-', leftVals, leftVals);
+		left.equip(effectiveWeapon);
+		
+		Statistics rightVals = new Statistics();
+		rightVals = rightVals.copy("HP", 20);
+		rightVals = rightVals.copy("Def", 3);
+		Unit right = new Unit("right", Class.createClass("Phantom"), '-', rightVals, rightVals);
+		
+		assertEquals(2 + 5 - 3, CombatCalculator.calculatePreviewStats(left, right, true).damage);
+	}
+	
+	@Test
 	public void calculatePreviewDamage_EffectiveTriangleDamage() {
 		Weapon effectiveWeapon = new Weapon(
 			"fork", 1, 0, 0,


### PR DESCRIPTION
This includes changing effectiveness calculations to occur inside a CombatTrigger instead of in the CombatCalculator. That Sol Katti has a different multiplier than everything else is still hardcoded, but I feel like hardcoding that in Weapon is easier to detangle than hardcoding it in CombatCalculator.

This should keep the weapon triangle's effects on effective damage intact.
