### PR TITLE
Increase robustness of travis's build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,15 @@ language: java
 
 jdk:
    - oraclejdk8
-   - oraclejdk9
-   - oraclejdk10
    - oraclejdk11
+   - openjdk11
+   - openjdk-ea
+
+matrix:
+   allow_failures:
+    - jdk: oraclejdk11
+    - jdk: openjdk11
+    - jdk: openjdk-ea
 
 script:
   - mkdir out


### PR DESCRIPTION
Travis is refusing to run oraclejdk10 builds because oraclejdk10 is unsupported. oraclejdk9 is just as unsupported, and it's willing to run those, but whatever. (as seen in <https://travis-ci.com/eliatlarge/FEMultiPlayer-V2/jobs/158996860>)

Anyway, what this branch does is remove the unsupported jdks from travis's build matrix, and marks the newer jdks as "allow_failures", which means travis will run the build script against those jdks but won't complain quite as loudly if those start failing spontaneously.